### PR TITLE
Export keys in index.ts

### DIFF
--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -1,3 +1,4 @@
+import { keys } from 'ts-transformer-keys'
 import * as PersonGroups from './person-groups'
 import * as Serials from './serials'
 
@@ -24,3 +25,17 @@ export type FilterForType<T extends Type> = {
   'person-groups': PersonGroups.Filter
   serials: Serials.Filter
 }[T]
+
+export const attributeKeys: { [T in Type]: (keyof AttributesForType<T>)[] } = {
+  'person-groups': keys<PersonGroups.Attributes>(),
+  serials: keys<Serials.Attributes>(),
+}
+
+export const relationshipKeys: {
+  [T in Type]: (keyof RelationshipsForType<T>)[]
+} = {
+  'person-groups': keys<PersonGroups.Relationships>(),
+  serials: keys<Serials.Relationships>(),
+}
+
+// TODO: sortables and filters

--- a/src/resources/person-groups.ts
+++ b/src/resources/person-groups.ts
@@ -1,4 +1,3 @@
-import { keys } from 'ts-transformer-keys'
 import { EqualFilter } from '../filter'
 import { Serials } from './index'
 

--- a/src/resources/person-groups.ts
+++ b/src/resources/person-groups.ts
@@ -18,6 +18,3 @@ export type Relationships = {
 export type SortField = never
 
 export type Filter = EqualFilter<Attributes, 'groupType'>
-
-export const attributeKeys = keys<Attributes>()
-export const relationshipKeys = keys<Relationships>()

--- a/src/resources/serials.ts
+++ b/src/resources/serials.ts
@@ -1,5 +1,3 @@
-import { keys } from 'ts-transformer-keys'
-
 import { PersonGroups } from './index'
 import { DateFilter, EqualFilter } from '../filter'
 import { Sort } from '../sort'
@@ -56,6 +54,3 @@ export type SortField = Sort<Attributes, 'createdAt' | 'updatedAt'>
 
 export type Filter = DateFilter<'created' | 'updated'> &
   EqualFilter<Attributes, 'serialType' | 's2oStatus'>
-
-export const attributeKeys = keys<Attributes>()
-export const relationshipKeys = keys<Relationships>()


### PR DESCRIPTION
I also removed the exports from the individual resources because it would mainly amount to redundant typing (the kind of typing you use your keyboard for) and therefore more potential sources of error.

With the current solution you get a compiler that complains when you define new types and, when pointed to the error's source, it shows you how it was implemented for the other types.