### PR TITLE
Add possibility to group multiple issues in serial-issues

### DIFF
--- a/src/resources/serial-issues.ts
+++ b/src/resources/serial-issues.ts
@@ -15,7 +15,7 @@ export type Attributes = Omit<
   year: number
   volume?: number
   issue?: number
-  issueOverride?: string
+  issueCount: number
   pageStart: number
   pageEnd: number
   publishedAt: Date
@@ -36,7 +36,6 @@ export type SortField =
   | 'year'
   | 'volume'
   | 'issue'
-  | 'issueOverride'
   | 'publishedAt'
 
 export type Filter = DateFilter<'created' | 'updated' | 'published'> &

--- a/src/resources/serial-issues.ts
+++ b/src/resources/serial-issues.ts
@@ -15,6 +15,7 @@ export type Attributes = Omit<
   year: number
   volume?: number
   issue?: number
+  issueOverride?: string
   pageStart: number
   pageEnd: number
   publishedAt: Date
@@ -35,6 +36,7 @@ export type SortField =
   | 'year'
   | 'volume'
   | 'issue'
+  | 'issueOverride'
   | 'publishedAt'
 
 export type Filter = DateFilter<'created' | 'updated' | 'published'> &


### PR DESCRIPTION
As suggested in https://github.com/ems-press/content-api/issues/159. There is no `issueCount` yet. Note that this is untested due to problems with `yalc` and `rush` / `pnpm` (I think).